### PR TITLE
Extract version value

### DIFF
--- a/edam2json/__main__.py
+++ b/edam2json/__main__.py
@@ -97,8 +97,11 @@ def print_biotools(args):
             biotools_node['children'].append(process_node(subroot_node, json_ld, args.extended))
     if args.extended:
         meta_node = [term for term in json_ld['@graph'] if term['@id']=='http://edamontology.org'][0]
+        version = meta_node['doap:Version']
+        if isinstance(version, dict) and '@value' in version:
+            version = version['@value']
         biotools_node['meta'] = {
-            'version': meta_node['doap:Version'],
+            'version': version,
             'date': meta_node['oboOther:date']
         }
     json.dump(biotools_node, args.output, sort_keys=True,


### PR DESCRIPTION
With version 1.25, the version now have a type and during the export, it is not "1.XX" but a dict. My fixe allows to extract the value when available.

Before :
```
$ edam2json EDAM_1.23.owl biotools  --extended
{
    "children": [],
    "data": {
        "uri": "owl:Thing"
    },
    "meta": {
        "date": "16.07.2019 19:43 UTC",
        "version": "1.23"
    }
}
$ edam2json EDAM.owl biotools  --extended
{
    "children": [],
    "data": {
        "uri": "owl:Thing"
    },
    "meta": {
        "date": "14.01.2020 13:23 UTC",
        "version": {
            "@type": "xsd:decimal",
            "@value": "1.25"
        }
    }
}
```


After :
```
$ edam2json EDAM_1.23.owl biotools  --extended
{
    "children": [],
    "data": {
        "uri": "owl:Thing"
    },
    "meta": {
        "date": "16.07.2019 19:43 UTC",
        "version": "1.23"
    }
}
$ edam2json EDAM.owl biotools  --extended
{
    "children": [],
    "data": {
        "uri": "owl:Thing"
    },
    "meta": {
        "date": "14.01.2020 13:23 UTC",
        "version": "1.25"
    }
}
```